### PR TITLE
allow to be built with -c as an independent compile unit

### DIFF
--- a/olcPGEX_Gamepad.h
+++ b/olcPGEX_Gamepad.h
@@ -80,6 +80,11 @@ few problems
 
 #endif
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#include <emscripten/html5.h>
+#endif
+
 namespace olc {
 #pragma region Enums
 #define GP_BUTTON_COUNT 18


### PR DESCRIPTION
When compiling as an independent compile unit, it's missing emscripten symbols

```bash
em++ -std=c++20 -c -IolcPixelGameEngine -IolcPixelGameEngine/extensions -IolcPixelGameEngine/utilities -Iminiaudio/0.11.21 -c olcPGEX_Gamepad/olcPGEX_Gamepad.cpp -o olcPGEX_Gamepad/olcPGEX_Gamepad.o
In file included from olcPGEX_Gamepad/olcPGEX_Gamepad.cpp:2:
olcPGEX_Gamepad/olcPGEX_Gamepad.h:1150:3: error: unknown type name 'EmscriptenGamepadEvent'
 1150 |   EmscriptenGamepadEvent state;
      |   ^
olcPGEX_Gamepad/olcPGEX_Gamepad.h:1182:39: error: use of undeclared identifier 'emscripten_sample_gamepad_data'
 1182 | void olc::GamePad::updateGamepads() { emscripten_sample_gamepad_data(); }
      |                                       ^
olcPGEX_Gamepad/olcPGEX_Gamepad.h:1196:35: error: unknown type name 'EmscriptenGamepadEvent'
 1196 |                             const EmscriptenGamepadEvent *gamepadEvent,
      |                                   ^
olcPGEX_Gamepad/olcPGEX_Gamepad.h:1200:22: error: use of undeclared identifier 'EMSCRIPTEN_EVENT_GAMEPADCONNECTED'
 1200 |     if (eventType == EMSCRIPTEN_EVENT_GAMEPADCONNECTED) {
      |                      ^
olcPGEX_Gamepad/olcPGEX_Gamepad.h:1214:3: error: use of undeclared identifier 'emscripten_set_gamepadconnected_callback'
 1214 |   emscripten_set_gamepadconnected_callback(&gamepads, true, gamepadCallback);
      |   ^
olcPGEX_Gamepad/olcPGEX_Gamepad.h:1215:3: error: use of undeclared identifier 'emscripten_set_gamepaddisconnected_callback'
 1215 |   emscripten_set_gamepaddisconnected_callback(&gamepads, true, gamepadCallback);
      |   ^
6 errors generated.
make: *** [Makefile:18: olcPGEX_Gamepad/olcPGEX_Gamepad.o] Error 1
```

This fixes that!